### PR TITLE
ci: Fix build on Debian 12

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
           iputils-ping \
           libegl1-mesa \
           libsdl1.2-dev \
-          pylint3 \
+          pylint \
           python3 \
           python3-git \
           python3-jinja2 \


### PR DESCRIPTION
This breaks building on older distributions, but we will surely not downgrade the CI.