### PR TITLE
ci: Update actions/checkout to v3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout code including full history and submodules
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
         fetch-depth: 0


### PR DESCRIPTION
This avoids the following warning:
> Node.js 12 actions are deprecated. Please update the following actions to use
> Node.js 16: actions/checkout@v2. For more information see:
> https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.