### PR TITLE
ci: Add support for automatic tagging of releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,22 @@
+on:
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - main
+
+jobs:
+  release:
+    if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'linux-system-') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Git tag
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/release/' + process.env.GITHUB_HEAD_REF,
+              sha: context.sha
+            })


### PR DESCRIPTION
On merge of a release pull request (with branch name linux-system-x.y.z) a corresponding Git tag is created.