### PR TITLE
bbwrapper.sh: Allow build directory in Btrfs subvolume

### DIFF
--- a/scripts/bbwrapper.sh
+++ b/scripts/bbwrapper.sh
@@ -7,6 +7,9 @@ set -e -o pipefail
 MACHINE="$1"
 BUILD_DIR="build-${MACHINE}"
 
+# Allow the build-directory to be stored on a different Btrfs volume
+export GIT_DISCOVERY_ACROSS_FILESYSTEM=1
+
 script_dir="$(dirname "$(readlink -f "$0")")"
 cd "${script_dir}"
 gitroot="$(git rev-parse --show-toplevel)"


### PR DESCRIPTION
To reduce the snapshot size of my Btrfs file systems, I put build directories in separate, not snapshotted subvolumes.

This change is needed to allow for this.