### PR TITLE
ci: Only build "main" branch when tagged

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,11 +5,9 @@ on:
     paths-ignore:
       - "README.md"
       - "doc/**"
-  workflow_run:
-    workflows:
-      - Release
-    types:
-      - completed
+  push:
+    tags:
+      - "release/*"
 
 jobs:
   build:


### PR DESCRIPTION
This prevents unnecessary builds for PRs that are closed without merge.