### PR TITLE
Add GitHub Codespaces/dev container support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "name": "smart-garden-gateway",
+  "image": "ghcr.io/husqvarnagroup/smart-garden-gateway-public/dev:latest",
+  "postCreateCommand": "git submodule update --init"
+}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,6 +74,24 @@ jobs:
             !build-${{ matrix.machine }}/tmp/deploy/spdx/*/by-hash
             !build-${{ matrix.machine }}/tmp/deploy/spdx/*/by-namespace
 
+      # Tar because sstate file names contain colons
+      - name: Pack sstate cache
+        if: >-
+          github.ref_type == 'tag'
+          || github.ref_name == 'main'
+        run: tar -cf sstate-cache-${{ matrix.machine }}.tar -C ~/.cache/yocto sstate-cache
+
+      - name: Upload sstate cache
+        if: >-
+          github.ref_type == 'tag'
+          || github.ref_name == 'main'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sstate-cache-${{ matrix.machine }}
+          path: sstate-cache-${{ matrix.machine }}.tar
+          # Cache is already Zstandard compressed
+          compression-level: 0
+
       - name: Generate dependency graph for debugging
         if: failure()
         run: scripts/bbwrapper.sh ${{ matrix.machine }} -g gardena-image-foss-bnw || true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,7 @@ on:
   push:
     tags:
       - "release/*"
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -104,3 +104,47 @@ jobs:
           path: |
             build-${{ matrix.machine }}/task-depends.dot
             build-${{ matrix.machine }}/tmp/work/**/temp/log.*
+
+  docker:
+    needs: build
+    if: >-
+      github.ref_type == 'tag'
+      || github.ref_name == 'main'
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+      packages: write
+
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}/dev
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download sstate cache artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: sstate-cache-*
+          path: sstate-artifacts
+          merge-multiple: true
+
+      - name: Add sstate caches to build context
+        run: |
+          for archive in sstate-artifacts/*.tar; do
+            tar -xf "${archive}" -C docker
+          done
+
+      - name: Log into container registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: docker
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code including full history and submodules
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
           fetch-depth: 0
@@ -65,7 +65,7 @@ jobs:
       # Ignoring spdx/by-* folders because the action can not deal with colons in
       # file names
       - name: Upload artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Build artifacts (${{ matrix.machine }})
           path: |
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload files for debugging build
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-debug-${{ matrix.machine }}
           path: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Create Git tag
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             github.rest.git.createRef({

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /build-*/
+
+# Populated by CI from the build artifacts before the image is built
+/docker/sstate-cache/*
+!/docker/sstate-cache/.gitkeep

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,1 @@
+/sstate-cache/.gitkeep

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,42 @@
+FROM debian:trixie
+
+RUN apt-get update && apt-get -qy --no-install-recommends install \
+    build-essential \
+    chrpath \
+    cpio \
+    debianutils \
+    diffstat \
+    file \
+    gawk \
+    gcc \
+    git \
+    iputils-ping \
+    libacl1 \
+    locales \
+    lz4 \
+    python3 \
+    python3-git \
+    python3-jinja2 \
+    python3-pexpect \
+    python3-pip \
+    python3-subunit \
+    socat \
+    sudo \
+    texinfo \
+    tig \
+    unzip \
+    vim \
+    wget \
+    xz-utils \
+    zstd \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN sed -i '/^# en_US.UTF-8 UTF-8/s/^# //' /etc/locale.gen && locale-gen
+ENV LANG=en_US.UTF-8
+
+RUN useradd --create-home --shell /bin/bash user \
+    && echo 'user ALL=(ALL) NOPASSWD:ALL' >/etc/sudoers.d/user
+
+USER user
+
+COPY --chown=user:user sstate-cache /home/user/.cache/yocto/sstate-cache


### PR DESCRIPTION
GitHub Codespaces allows interactively building/developing the project in the browser. With the configured Docker image which comes with a  pre-populated sstate cache, the limited 32 GB disk space is enough for building Yocto.

