### PR TITLE
Misc CI changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -198,6 +198,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Compose dev image tags
+        id: tags_dev
+        run: |
+          {
+            echo 'tags<<END_OF_TAGS'
+            echo "${DEV_IMAGE_NAME}:latest"
+            if [ "${GITHUB_REF_TYPE}" = tag ]; then
+              echo "${DEV_IMAGE_NAME}:${GITHUB_REF_NAME#gardena/}"
+            fi
+            echo END_OF_TAGS
+          } >>"${GITHUB_OUTPUT}"
+
       - name: Build and push dev image
         id: dev-image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -205,7 +217,19 @@ jobs:
           context: docker
           file: docker/dev.dockerfile
           push: true
-          tags: ${{ env.DEV_IMAGE_NAME }}:latest
+          tags: ${{ steps.tags_dev.outputs.tags }}
+
+      - name: Compose CI image tags
+        id: tags_ci
+        run: |
+          {
+            echo 'tags<<END_OF_TAGS'
+            echo "${CI_IMAGE_NAME}:latest"
+            if [ "${GITHUB_REF_TYPE}" = tag ]; then
+              echo "${CI_IMAGE_NAME}:${GITHUB_REF_NAME#gardena/}"
+            fi
+            echo END_OF_TAGS
+          } >>"${GITHUB_OUTPUT}"
 
       - name: Build and push CI image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -213,6 +237,6 @@ jobs:
           context: docker
           file: docker/ci.dockerfile
           push: true
-          tags: ${{ env.CI_IMAGE_NAME }}:latest
+          tags: ${{ steps.tags_ci.outputs.tags }}
           build-args: |
             BASE_IMAGE=${{ env.DEV_IMAGE_NAME }}@${{ steps.dev-image.outputs.digest }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,12 @@ on:
   push:
     tags:
       - "gardena/v*"
+  workflow_call:
+    inputs:
+      ref:
+        description: Commit, branch or tag (defaults to event's ref)
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       runner:
@@ -59,6 +65,7 @@ jobs:
       - name: Checkout code including full history and submodules
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ inputs.ref }}
           submodules: true
           fetch-depth: 0
 
@@ -177,6 +184,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Download sstate cache artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ on:
       - "doc/**"
   push:
     tags:
-      - "release/*"
+      - "gardena/v*"
   workflow_dispatch:
     inputs:
       runner:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,16 +9,27 @@ on:
 
 jobs:
   release:
-    if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'linux-system-') }}
+    if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'gardena/release/') }}
     runs-on: ubuntu-24.04
+    outputs:
+      tag: ${{ steps.tag.outputs.result }}
     steps:
       - name: Create Git tag
+        id: tag
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
+          result-encoding: string
           script: |
-            github.rest.git.createRef({
+            const branch = process.env.GITHUB_HEAD_REF
+            const match = branch.match(/^gardena\/release\/(v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$/)
+            if (!match) {
+              throw new Error(`${branch} does not contain a valid version`)
+            }
+            const tag = 'gardena/' + match[1]
+            await github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'refs/tags/release/' + process.env.GITHUB_HEAD_REF,
+              ref: 'refs/tags/' + tag,
               sha: context.sha
             })
+            return tag

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,3 +33,13 @@ jobs:
               sha: context.sha
             })
             return tag
+
+  # Creating a tag with GITHUB_TOKEN does not trigger a build, so call the workflow here for the tag
+  build:
+    needs: release
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/build.yaml
+    with:
+      ref: refs/tags/${{ needs.release.outputs.tag }}

--- a/scripts/bbwrapper.sh
+++ b/scripts/bbwrapper.sh
@@ -20,8 +20,8 @@ if ! type bitbake >/dev/null 2>&1; then
   sed -i 's/\(^MACHINE ??= "\).*\(".*\)/\1'gardena-sg-${MACHINE}'\2/g' conf/local.conf
 fi
 
-# Using git and annotated tags in the form or release/linux-system-X.Y.Z[-suffix] to determine the distribution version.
-DISTRO_VERSION_ID="$(git describe --tags --dirty --match release/linux-system* | cut -c 22-)"
+# Deriving the distribution version from the newest tag in the form of gardena/vX.Y.Z[-suffix].
+DISTRO_VERSION_ID="$(git describe --tags --dirty --match gardena/v* | cut -d v -f 2- || git describe --tags --dirty --match release/linux-system* | cut -c 22-)"
 DISTRO_VERSION="$(echo "${DISTRO_VERSION_ID}" | egrep -o '[0-9]+\.[0-9]+\.[0-9]+' )"
 DISTRO_UPDATE_URL="${DISTRO_UPDATE_URL:-http://10.42.0.1:8000/gardena-update-image-prod-gardena-sg-${MACHINE}.swu}"
 DISTRO_UPDATE_URL_BASE="${DISTRO_UPDATE_URL_BASE:-http://gateway.iot.sg.dss.husqvarnagroup.net/images}"


### PR DESCRIPTION
Release PRs will now have to be pushed to a `gardena/release/vX.Y.Z` branch. On PR merge, a `gardena/vX.Y.Z` tag will automatically be created for which then a full build will be triggered.

Test runs:
- https://github.com/easybe/smart-garden-gateway-public/actions/runs/33664355328
- https://github.com/easybe/smart-garden-gateway-public/actions/runs/33666751175